### PR TITLE
add Select mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Yazi plugin which like flash.nvim in Neovim, allow use key char to precise sel
 
 keep mode, when select a dir, it will auto enter and keep in "keyjump" mode.
 
-When select a file or press <ESC> or select no match, it will leave "keyjump" mode.
+When select a file or press <ESC> , it will leave "keyjump" mode.
 
 https://github.com/DreamMaoMao/keyjump.yazi/assets/30348075/dd998a34-49b0-481d-b032-d9849a89ba48
 
@@ -15,6 +15,12 @@ https://github.com/DreamMaoMao/keyjump.yazi/assets/30348075/dd998a34-49b0-481d-b
 Normal mode, when select a item, it will auto leave keyjump mode
 
 https://github.com/DreamMaoMao/keyjump/assets/30348075/6ba722ce-8b55-4c80-ac81-b6b7ade74491
+
+## Normal mode
+
+Select mode, you can use "<Space>" key to select/unselect item, and press <Esc> to exit.
+
+
 
 ## Install
 
@@ -50,6 +56,14 @@ on   = [ "i" ]
 exec = "plugin keyjump --sync"
 desc = "Keyjump (Normal mode)"
 ```
+
+```toml
+[[manager.prepend_keymap]]
+on   = [ "i" ]
+exec = "plugin keyjump --sync --args=select"
+desc = "Keyjump (Normal mode)"
+```
+
 
 When you see some character(singal character or double character) in left of the entry.
 Press the key of the character will jump to the corresponding entry

--- a/init.lua
+++ b/init.lua
@@ -171,7 +171,7 @@ return {
 
 			local cand = ya.which { cands = cands, silent = true }
 
-			if cand == nil then --does't automatically exit when pressing a nonexistent prompt key
+			if cand == nil then --never auto exit when pressing a nonexistent prompt key
 				return next(false, { "_read", num})
 			else
 				return next(true, { "_apply", cand, num} )
@@ -189,6 +189,11 @@ return {
 		local entry_num = tonumber(args[3]) 
 		local folder = Folder:by_kind(Folder.CURRENT)
 
+		-- hit esc key
+		if cand > entry_num and SPECIAL_KEYS[cand - entry_num] == "<Esc>" then 
+			return
+		end
+
 		-- Step 4: select mode, allow use special key in keyjump
 		if state.type == "select" then
 			if cand <= entry_num then -- hit normal key
@@ -199,14 +204,12 @@ return {
 				return
 			end
 
-			-- hit special key
+			-- hit space key
 			if SPECIAL_KEYS[cand - entry_num] == " " then
 				local under_cursor_file = Folder:by_kind(Folder.CURRENT).window[folder.cursor - folder.offset + 1 ]
 				local toggle_state = under_cursor_file:is_selected() and "false" or "true"
 				ya.manager_emit("select", { state=toggle_state })
 				ya.manager_emit("arrow", { 1 })
-			elseif SPECIAL_KEYS[cand - entry_num] == "<Esc>" then
-				return
 			end
 
 			--never auto exit select mode
@@ -214,7 +217,7 @@ return {
 			return
 		end
 	
-		-- arrow in keep mode
+		-- arrow in keep mode and normal mode
 		ya.manager_emit("arrow", { cand - 1 + folder.offset - folder.cursor })
 
 		-- Step 5: keep mode, will auto enter when select folder and will auto exit when select file

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,9 @@
 -- stylua: ignore
+local SPECIAL_KEYS = {
+	" ","<Esc>"
+}
+
+-- stylua: ignore
 local SINGLE_KEYS = {
 	"p", "b", "e", "t", "a", "o", "i", "n", "s", "r", "h", "l", "d", "c",
 	"u", "m", "f", "g", "w", "v", "k", "j", "x", "z", "y", "q"
@@ -12,6 +17,12 @@ local DOUBLE_KEYS = {
 	"ru", "ri", "ro", "rh", "rj", "rk", "rl", "rn", "cu", "ci", "co", "ch",
 	"cj", "ck", "cl", "cn", "wu", "wi", "wo", "wh", "wj", "wk", "wl", "wn"
 }
+
+-- stylua: ignore
+local SPECIAL_CANDS = {
+	{ on = " " },{ on = "<ESC>" }
+}
+
 -- stylua: ignore
 local SIGNAL_CANDS = {
 	{ on = "p" }, { on = "b" }, { on = "e" }, { on = "t" }, { on = "a" },
@@ -62,7 +73,7 @@ end
 local function count_files(url, max)
 	local cmd
 	if ya.target_family() == "windows" then
-		cmd = cx.active.conf.show_hidden and "dir /b /a " or "dir /b "
+		cmd = cx.active.conf.show_hidden and "dir /a " or "dir "
 		cmd = cmd .. ya.quote(tostring(url))
 	else
 		cmd = cx.active.conf.show_hidden and "ls -A  " or "ls "
@@ -132,7 +143,7 @@ return {
 		local action = args[1]
 
 		-- Step 1: Patch the UI with our candidates
-		if not action or action == "keep" then
+		if not action or action == "keep" or action == "select" then
 			if #SINGLE_KEYS >= Current.area.h then
 				state.num = Current.area.h -- Fast path
 			else
@@ -142,7 +153,7 @@ return {
 				end
 			end
 
-			state.keep = action == "keep"
+			state.type = action
 			toggle_ui(state())
 			return next(false, { "_read", state.num })
 		end
@@ -156,8 +167,12 @@ return {
 				cands = { table.unpack(SIGNAL_CANDS, 1, num) }
 			end
 
+			for i = 1, #SPECIAL_KEYS do --attach special key 
+				table.insert(cands, SPECIAL_CANDS[i])
+			end
+
 			local cand = ya.which { cands = cands, silent = true }
-			return next(true, cand and { "_apply", cand } or { "_reset" })
+			return next(true, cand and { "_apply", cand, num} or { "_reset" })
 		end
 
 		-- Step 3: Restore the UI we patched in step 1, once we read the candidate
@@ -166,13 +181,36 @@ return {
 			return
 		end
 
-		-- Step 4: Apply the candidate by moving the cursor of the file list
-		local folder = Folder:by_kind(Folder.CURRENT)
 		local cand = tonumber(args[2])
+		local entry_num = tonumber(args[3]) 
+		local folder = Folder:by_kind(Folder.CURRENT)
+
+		-- Step 4: select mode, allow use special key in keyjump
+		if state.type == "select" then
+			if cand <= entry_num then -- hit normal key
+				local folder = Folder:by_kind(Folder.CURRENT)
+				ya.manager_emit("arrow", { cand - 1 + folder.offset - folder.cursor })
+
+				next(true, { "select" })
+				return
+			end
+
+			if SPECIAL_KEYS[cand - entry_num] == " " then
+				local under_cursor_file = Folder:by_kind(Folder.CURRENT).window[folder.cursor - folder.offset + 1 ]
+				local toggle_state = under_cursor_file:is_selected() and "false" or "true"
+				ya.manager_emit("select", { state=toggle_state })
+				ya.manager_emit("arrow", { 1 })
+			end
+
+			next(true, { "select" })
+			return
+		end
+	
 		ya.manager_emit("arrow", { cand - 1 + folder.offset - folder.cursor })
 
-		-- Step 5: If keep mode is enabled, return to step 1
-		if state.keep and folder.window[cand].cha.is_dir then
+		-- Step 5: keep mode, will auto enter when select folder and will auto exit when select file
+		if state.type == "keep" and folder.window[cand].cha.is_dir then
+			local folder = Folder:by_kind(Folder.CURRENT)
 			ya.manager_emit("enter", {})
 			next(true, { "keep" })
 		end


### PR DESCRIPTION

https://github.com/DreamMaoMao/keyjump.yazi/assets/30348075/4c23559b-c690-4464-a966-ea611a9614cc

1.keep mode will not automatically exit if you press the wrong prompt key.
2. Added select mode. This mode will not automatically enter the folder. You can use the space key to select and unselect files and directories. Press the esc key to exit.